### PR TITLE
replaced 3 OHMI relations that labels match RO labels with RO terms

### DIFF
--- a/src/ontology/Ontofox_inputs/NCBITaxon_input.txt
+++ b/src/ontology/Ontofox_inputs/NCBITaxon_input.txt
@@ -296,6 +296,9 @@ http://purl.obolibrary.org/obo/NCBITaxon_1898203 #Lachnospiraceae bacterium
 http://purl.obolibrary.org/obo/NCBITaxon_472977 # Natronobacillus
 http://purl.obolibrary.org/obo/NCBITaxon_32045 # unclassified Proteobacteria
 http://purl.obolibrary.org/obo/NCBITaxon_946234 
+http://purl.obolibrary.org/obo/NCBITaxon_33090 #Viridiplantae  (green plants)
+http://purl.obolibrary.org/obo/NCBITaxon_1236 #Gammaproteobacteria
+
 
 # ID changed
 http://purl.obolibrary.org/obo/NCBITaxon_3052230 #NCBITaxon_11103

--- a/src/ontology/Ontofox_inputs/RO_input.txt
+++ b/src/ontology/Ontofox_inputs/RO_input.txt
@@ -14,6 +14,9 @@ http://purl.obolibrary.org/obo/RO_0000087 #has role
 http://purl.obolibrary.org/obo/RO_0000091 #has disposition
 http://purl.obolibrary.org/obo/RO_0002351 #has member
 http://purl.obolibrary.org/obo/RO_0003000 #produces
+http://purl.obolibrary.org/obo/RO_0016002 #has disease
+http://purl.obolibrary.org/obo/RO_0002200 #has phenotype
+http://purl.obolibrary.org/obo/RO_0002454 #has host
 
 http://purl.obolibrary.org/obo/RO_0002222 #temporallly related to
 includeAllChildren

--- a/src/ontology/Ontofox_outputs/NCBITaxon_import.owl
+++ b/src/ontology/Ontofox_outputs/NCBITaxon_import.owl
@@ -719,7 +719,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437183">
         <rdfs:label>Mesangiospermae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
         <obo:IAO_0000111>Mesangiospermae</obo:IAO_0000111>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
@@ -2274,13 +2274,13 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3052230">
         <rdfs:label>Hepacivirus hominis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2559587"/>
+        <obo:IAO_0000118>hepatitis C virus HCV</obo:IAO_0000118>
         <obo:IAO_0000118>human hepatitis virus C HCV</obo:IAO_0000118>
         <obo:IAO_0000118>human hepatitis C virus</obo:IAO_0000118>
         <obo:IAO_0000118>post-transfusion hepatitis non A non B virus</obo:IAO_0000118>
         <obo:IAO_0000118>Hepacivirus C</obo:IAO_0000118>
-        <obo:IAO_0000118>Hepatitis C virus</obo:IAO_0000118>
-        <obo:IAO_0000118>hepatitis C virus HCV</obo:IAO_0000118>
         <obo:IAO_0000118>human hepatitis C virus HCV</obo:IAO_0000118>
+        <obo:IAO_0000118>Hepatitis C virus</obo:IAO_0000118>
         <obo:IAO_0000111>Hepacivirus hominis</obo:IAO_0000111>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
@@ -2551,6 +2551,20 @@
         <rdfs:label>Coprococcus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186803"/>
         <obo:IAO_0000111>Coprococcus</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_33090 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33090">
+        <rdfs:label>Viridiplantae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000118>green plants</obo:IAO_0000118>
+        <obo:IAO_0000118>Chlorophyta/Embryophyta group</obo:IAO_0000118>
+        <obo:IAO_0000111>Viridiplantae</obo:IAO_0000111>
+        <obo:IAO_0000118>chlorophyte/embryophyte group</obo:IAO_0000118>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     

--- a/src/ontology/Ontofox_outputs/RO_import.owl
+++ b/src/ontology/Ontofox_outputs/RO_import.owl
@@ -6,9 +6,11 @@
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/">
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/ohmi/RO_import.owl"/>
     
 
@@ -21,30 +23,11 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
-        <obo:IAO_0000589>is defined by</obo:IAO_0000589>
-    </rdf:Description>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001900">
         <rdfs:label>temporal interpretation</rdfs:label>
         <obo:IAO_0000115>An assertion that holds between an OWL Object Property and a temporal interpretation that elucidates how OWL Class Axioms that use this property are to be interpreted in a temporal context.</obo:IAO_0000115>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
         <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/ro/docs/temporal-semantics/"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002416">
-        <rdfs:label xml:lang="en">logical macro assertion</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/ro/docs/shortcut-relations/</rdfs:seeAlso>
-        <obo:IAO_0000115>An assertion that involves at least one OWL object that is intended to be expanded into one or more logical axioms. The logical expansion can yield axioms expressed using any formal logical system, including, but not limited to OWL2-DL.</obo:IAO_0000115>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000424">
-        <rdfs:label xml:lang="en">expand expression to</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">A macro expansion tag applied to an object property (or possibly a data property)  which can be used by a macro-expansion engine to generate more complex expressions from simpler ones</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Chris Mungall</obo:IAO_0000117>
-        <obo:IAO_0000112 xml:lang="en">ObjectProperty: RO_0002104
-Label: has plasma membrane part
-Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (http://purl.org/obo/owl/GO#GO_0005886 and http://purl.obolibrary.org/obo/BFO_0000051 some ?Y)&quot;
-</obo:IAO_0000112>
-        <obo:IAO_0000111 xml:lang="en">expand expression to</obo:IAO_0000111>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600">
         <rdfs:label xml:lang="en">elucidation</rdfs:label>
@@ -52,26 +35,6 @@ Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (
         <obo:IAO_0000600 xml:lang="en">Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms</obo:IAO_0000600>
         <obo:IAO_0000111 xml:lang="en">elucidation</obo:IAO_0000111>
         <obo:IAO_0000117 xml:lang="en">person:Alan Ruttenberg</obo:IAO_0000117>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
-        <rdfs:label xml:lang="en">OBO foundry unique label</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which is unique across the OBO Foundry.</obo:IAO_0000115>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBO Foundry &lt;http://obofoundry.org/&gt;</obo:IAO_0000119>
-        <obo:IAO_0000111 xml:lang="en">OBO foundry unique label</obo:IAO_0000111>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Bjoern Peters</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Chris Mungall</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <obo:IAO_0000116 xml:lang="en">The intended usage of that property is as follow: OBO foundry unique labels are automatically generated based on regular expressions provided by each ontology, so that SO could specify unique label = &#39;sequence &#39; + [label], etc. , MA could specify &#39;mouse + [label]&#39; etc. Upon importing terms, ontology developers can choose to use the &#39;OBO foundry unique label&#39; for an imported term or not. The same applies to tools .</obo:IAO_0000116>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002579">
-        <rdfs:label>is indirect form of</rdfs:label>
-        <obo:IAO_0000115>relation p is the indirect form of relation q iff p is a subPropertyOf q, and there exists some p&#39; such that p&#39; is the direct form of q, p&#39; o p&#39; -&gt; p, and forall x,y : x q y -&gt; either (1) x p y or (2) x p&#39; y</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
-        <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/ro/docs/direct-and-indirect-relations/"/>
-        <terms:creator rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
         <rdfs:label>has_related_synonym</rdfs:label>
@@ -82,46 +45,12 @@ Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (
         <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
     </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
     <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/homepage"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004048">
-        <rdfs:label>is directional form of</rdfs:label>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-03-13T23:59:29Z</oboInOwl:creation_date>
-        <obo:IAO_0000115>Used to annotate object properties representing a causal relationship where the value indicates a direction. Should be &quot;+&quot;, &quot;-&quot; or &quot;0&quot;</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
-        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004049">
-        <rdfs:label>is positive form of</rdfs:label>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-03-14T00:03:16Z</oboInOwl:creation_date>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0004048"/>
-        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date"/>
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/creator"/>
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/source"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002423">
-        <rdfs:label xml:lang="en">logical macro assertion on an annotation property</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002421"/>
-    </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#inSubset">
         <rdfs:label>in_subset</rdfs:label>
     </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002422">
-        <rdfs:label xml:lang="en">logical macro assertion on an object property</rdfs:label>
-        <obo:IAO_0000115>Used to annotate object properties to describe a logical meta-property or characteristic of the object property.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002421"/>
-    </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/created"/>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002421">
-        <rdfs:label xml:lang="en">logical macro assertion on a property</rdfs:label>
-        <obo:IAO_0000115>A logical macro assertion whose domain is an IRI for a property</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002416"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description"/>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
         <rdfs:label xml:lang="en">alternative label</rdfs:label>
         <rdfs:comment>Consider re-defing to: An alternative name for a class or property which can mean the same thing as the preferred name (semantically equivalent, narrow, broad or related).</rdfs:comment>
@@ -132,6 +61,7 @@ Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (
         <obo:IAO_0000111 xml:lang="en">alternative label</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor"/>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
         <rdfs:label xml:lang="en">term editor</rdfs:label>
         <obo:IAO_0000116 xml:lang="en">20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115.</obo:IAO_0000116>
@@ -174,9 +104,6 @@ Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000111 xml:lang="en">editor note</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-    </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
         <rdfs:label>definition</rdfs:label>
@@ -250,6 +177,8 @@ We also have the outstanding issue of how to aim different definitions to differ
         <obo:IAO_0000111 xml:lang="en">curator note</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/date"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id"/>
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
         <rdfs:label>has_exact_synonym</rdfs:label>
         <rdfs:label xml:lang="en">has exact synonym</rdfs:label>
@@ -259,12 +188,125 @@ We also have the outstanding issue of how to aim different definitions to differ
         <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
     </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#closeMatch"/>
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004050">
         <rdfs:label>is negative form of</rdfs:label>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-03-14T00:03:24Z</oboInOwl:creation_date>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0004048"/>
         <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
+    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+        <obo:IAO_0000589>is defined by</obo:IAO_0000589>
+    </rdf:Description>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002416">
+        <rdfs:label xml:lang="en">logical macro assertion</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/ro/docs/shortcut-relations/</rdfs:seeAlso>
+        <obo:IAO_0000115>An assertion that involves at least one OWL object that is intended to be expanded into one or more logical axioms. The logical expansion can yield axioms expressed using any formal logical system, including, but not limited to OWL2-DL.</obo:IAO_0000115>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000424">
+        <rdfs:label xml:lang="en">expand expression to</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A macro expansion tag applied to an object property (or possibly a data property)  which can be used by a macro-expansion engine to generate more complex expressions from simpler ones</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Chris Mungall</obo:IAO_0000117>
+        <obo:IAO_0000112 xml:lang="en">ObjectProperty: RO_0002104
+Label: has plasma membrane part
+Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (http://purl.org/obo/owl/GO#GO_0005886 and http://purl.obolibrary.org/obo/BFO_0000051 some ?Y)&quot;
+</obo:IAO_0000112>
+        <obo:IAO_0000111 xml:lang="en">expand expression to</obo:IAO_0000111>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
+        <rdfs:label xml:lang="en">OBO foundry unique label</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which is unique across the OBO Foundry.</obo:IAO_0000115>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBO Foundry &lt;http://obofoundry.org/&gt;</obo:IAO_0000119>
+        <obo:IAO_0000111 xml:lang="en">OBO foundry unique label</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Chris Mungall</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000116 xml:lang="en">The intended usage of that property is as follow: OBO foundry unique labels are automatically generated based on regular expressions provided by each ontology, so that SO could specify unique label = &#39;sequence &#39; + [label], etc. , MA could specify &#39;mouse + [label]&#39; etc. Upon importing terms, ontology developers can choose to use the &#39;OBO foundry unique label&#39; for an imported term or not. The same applies to tools .</obo:IAO_0000116>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002579">
+        <rdfs:label>is indirect form of</rdfs:label>
+        <obo:IAO_0000115>relation p is the indirect form of relation q iff p is a subPropertyOf q, and there exists some p&#39; such that p&#39; is the direct form of q, p&#39; o p&#39; -&gt; p, and forall x,y : x q y -&gt; either (1) x p y or (2) x p&#39; y</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
+        <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/ro/docs/direct-and-indirect-relations/"/>
+        <terms:creator rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004048">
+        <rdfs:label>is directional form of</rdfs:label>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-03-13T23:59:29Z</oboInOwl:creation_date>
+        <obo:IAO_0000115>Used to annotate object properties representing a causal relationship where the value indicates a direction. Should be &quot;+&quot;, &quot;-&quot; or &quot;0&quot;</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0004049">
+        <rdfs:label>is positive form of</rdfs:label>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-03-14T00:03:16Z</oboInOwl:creation_date>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0004048"/>
+        <oboInOwl:created_by rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/creator"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002423">
+        <rdfs:label xml:lang="en">logical macro assertion on an annotation property</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002421"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002422">
+        <rdfs:label xml:lang="en">logical macro assertion on an object property</rdfs:label>
+        <obo:IAO_0000115>Used to annotate object properties to describe a logical meta-property or characteristic of the object property.</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002421"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002421">
+        <rdfs:label xml:lang="en">logical macro assertion on a property</rdfs:label>
+        <obo:IAO_0000115>A logical macro assertion whose domain is an IRI for a property</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002416"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002420">
+        <rdfs:label xml:lang="en">logical macro assertion on a class</rdfs:label>
+        <obo:IAO_0000115>A logical macro assertion whose domain is an IRI for a class</obo:IAO_0000115>
+        <obo:IAO_0000116>The domain for this class can be considered to be owl:Class, but we cannot assert this in OWL2-DL</obo:IAO_0000116>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002416"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0002000">
+        <rdfs:label>defined by construct</rdfs:label>
+        <obo:IAO_0000112>&#39;part disjoint with&#39; &#39;defined by construct&#39; &quot;&quot;&quot;
+    PREFIX owl: &lt;http://www.w3.org/2002/07/owl#&gt;
+    PREFIX : &lt;http://example.org/
+    CONSTRUCT {
+      [
+        a owl:Restriction ;
+        owl:onProperty :part_of ;
+        owl:someValuesFrom ?a ;
+          a owl:Restriction ;
+          owl:onProperty :part_of ;
+          owl:someValuesFrom ?b
+        ]
+      ]
+    }
+    WHERE {
+      ?a :part_disjoint_with ?b .
+    }</obo:IAO_0000112>
+        <obo:IAO_0000115>Links an annotation property to a SPARQL CONSTRUCT query which is meant to provide semantics for a shortcut relation.</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/ontodev/robot/issues/963"/>
+        <dc:contributor rdf:resource="https://orcid.org/0000-0002-7356-1779"/>
+        <dc:contributor rdf:resource="https://orcid.org/0000-0002-8688-6599"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002172">
+        <rdfs:label xml:lang="en">taxonomic class assertion</rdfs:label>
+        <obo:IAO_0000115>An assertion that holds between an ontology class and an organism taxon class, which is intepreted to yield some relationship between instances of the ontology class and the taxon.</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002420"/>
+        <rdfs:seeAlso rdf:resource="https://github.com/obophenotype/uberon/wiki/Taxon-constraints"/>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002575">
         <rdfs:label>is direct form of</rdfs:label>
@@ -281,6 +323,39 @@ Where we have an annotation assertion
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002422"/>
         <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/ro/docs/direct-and-indirect-relations/"/>
         <terms:creator rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002175">
+        <rdfs:label xml:lang="en">present in taxon</rdfs:label>
+        <obo:OMO_0002000>PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+PREFIX owl: &lt;http://www.w3.org/2002/07/owl#&gt;
+PREFIX in_taxon: &lt;http://purl.obolibrary.org/obo/RO_0002162&gt;
+PREFIX present_in_taxon: &lt;http://purl.obolibrary.org/obo/RO_0002175&gt;
+CONSTRUCT {
+  in_taxon: a owl:ObjectProperty .
+  ?witness rdfs:label ?label .
+  ?witness rdfs:subClassOf ?x .
+  ?witness rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty in_taxon: ;
+    owl:someValuesFrom ?taxon
+  ] .
+}
+WHERE {
+  ?x present_in_taxon: ?taxon .
+  BIND(IRI(CONCAT(
+    &quot;http://purl.obolibrary.org/obo/RO_0002175#&quot;,
+    MD5(STR(?x)),
+    &quot;-&quot;,
+    MD5(STR(?taxon))
+  )) as ?witness)
+  BIND(CONCAT(STR(?x), &quot; in taxon &quot;, STR(?taxon)) AS ?label)
+}</obo:OMO_0002000>
+        <rdfs:comment>The SPARQL expansion for this relation introduces new named classes into the ontology. For this reason it is likely that the expansion should only be performed during a QC pipeline; the expanded output should usually not be included in a published version of the ontology.</rdfs:comment>
+        <obo:IAO_0000115>S present_in_taxon T if some instance of T has some S. This does not means that all instances of T have an S - it may only be certain life stages or sexes that have S</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002172"/>
+        <obo:IAO_0000119 rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/22293552"/>
+        <rdfs:seeAlso rdf:resource="https://github.com/obophenotype/uberon/wiki/Taxon-constraints"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
     </owl:AnnotationProperty>
     
 
@@ -427,15 +502,15 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002086"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002092"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002091"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002092"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062"/>
         </owl:propertyChainAxiom>
     </owl:ObjectProperty>
@@ -671,10 +746,6 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
         <obo:RO_0001900 rdf:resource="http://purl.obolibrary.org/obo/RO_0001901"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001025"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        </owl:propertyChainAxiom>
         <rdfs:range>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -685,6 +756,10 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
                 </owl:intersectionOf>
             </owl:Class>
         </rdfs:range>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001025"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        </owl:propertyChainAxiom>
         <rdfs:domain>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -969,20 +1044,20 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002323"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002131"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002131"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
         </owl:propertyChainAxiom>
     </owl:ObjectProperty>
     
@@ -1001,6 +1076,46 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
         <obo:RO_0001900 rdf:resource="http://purl.obolibrary.org/obo/RO_0001901"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002200 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002200">
+        <rdfs:label xml:lang="en">has phenotype</rdfs:label>
+        <obo:IAO_0000115>A relationship that holds between a biological entity and a phenotype. Here a phenotype is construed broadly as any kind of quality of an organism part, a collection of these qualities, or a change in quality or qualities (e.g. abnormally increased temperature). The subject of this relationship can be an organism (where the organism has the phenotype, i.e. the qualities inhere in parts of this organism), a genomic entity such as a gene or genotype (if modifications of the gene or the genotype causes the phenotype), or a condition such as a disease (such that if the condition inheres in an organism, then the organism has the phenotype).</obo:IAO_0000115>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002201"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0016001"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/UPHENO_0001001"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+        <rdfs:domain>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OGMS_0000031"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:domain>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002201 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002201">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:label xml:lang="en">phenotype of</rdfs:label>
+        <obo:IAO_0000115>inverse of has phenotype</obo:IAO_0000115>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/RO_0002259"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
     </owl:ObjectProperty>
     
 
@@ -1032,12 +1147,12 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002578"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002230"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002025"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002230"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
         </owl:propertyChainAxiom>
     </owl:ObjectProperty>
     
@@ -1305,13 +1420,27 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <obo:IAO_0000119 rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/20064205"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000052"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002314"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
         </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000052"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002321 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002321">
+        <rdfs:label xml:lang="en">ecologically related to</rdfs:label>
+        <obo:IAO_0000116>Awaiting class for domain/range constraint, see: https://github.com/OBOFoundry/Experimental-OBO-Core/issues/6</obo:IAO_0000116>
+        <obo:IAO_0000115>A relationship that is mediated in some way by the environment or environmental feature (ENVO:00002297)</obo:IAO_0000115>
+        <obo:IAO_0000232>Do not use this relation directly. It is intended as a grouping for a diverse set of relations, all involving ecological interactions</obo:IAO_0000232>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
     </owl:ObjectProperty>
     
 
@@ -1471,20 +1600,20 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002629"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002407"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
-        </owl:propertyChainAxiom>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002407"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002629"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002629"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002629"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002629"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002407"/>
+        </owl:propertyChainAxiom>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
         </owl:propertyChainAxiom>
     </owl:ObjectProperty>
     
@@ -1504,12 +1633,12 @@ A continuant cannot have an occurrent as part: use &#39;participates in&#39;. An
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
         <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002630"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002630"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002409"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002630"/>
         </owl:propertyChainAxiom>
         <owl:propertyChainAxiom rdf:parseType="Collection">
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002630"/>
@@ -1651,6 +1780,119 @@ Each of these 3 primitives can be composed to yield a cross-product of different
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0002434 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002434">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:label>interacts with</rdfs:label>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">Considering relabeling as &#39;pairwise interacts with&#39;</obo:IAO_0000116>
+        <skos:closeMatch rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/MI_0914</skos:closeMatch>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/ro/docs/interaction-relations/</rdfs:seeAlso>
+        <oboInOwl:hasExactSynonym>in pairwise interaction with</oboInOwl:hasExactSynonym>
+        <obo:IAO_0000116>This relation and all sub-relations can be applied to either (1) pairs of entities that are interacting at any moment of time (2) populations or species of entity whose members have the disposition to interact (3) classes whose members have the disposition to interact.</obo:IAO_0000116>
+        <obo:IAO_0000115>A relationship that holds between two entities in which the processes executed by the two entities are causally connected.</obo:IAO_0000115>
+        <obo:IAO_0000232>Note that this relationship type, and sub-relationship types may be redundant with process terms from other ontologies. For example, the symbiotic relationship hierarchy parallels GO. The relations are provided as a convenient shortcut. Consider using the more expressive processual form to capture your data. In the future, these relations will be linked to their cognate processes through rules.</obo:IAO_0000232>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002437 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002437">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:label>biotically interacts with</rdfs:label>
+        <rdfs:seeAlso>http://eol.org/schema/terms/interactsWith</rdfs:seeAlso>
+        <obo:IAO_0000118>interacts with on organism level</obo:IAO_0000118>
+        <obo:IAO_0000115>An interaction relationship in which at least one of the partners is an organism and the other is either an organism or an abiotic entity with which the organism interacts.</obo:IAO_0000115>
+        <rdfs:seeAlso rdf:resource="http://dx.doi.org/10.1016/j.ecoinf.2014.08.005"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002321"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002434"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002440 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002440">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:label>symbiotically interacts with</rdfs:label>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.ncbi.nlm.nih.gov/pubmed/19278549</obo:IAO_0000119>
+        <obo:IAO_0000115>A biotic interaction in which the two organisms live together in more or less intimate association.</obo:IAO_0000115>
+        <obo:IAO_0000232>We follow GO and PAMGO in using &#39;symbiosis&#39; as the broad term encompassing mutualism through parasitism</obo:IAO_0000232>
+        <obo:IAO_0000112>whales symbiotically interact with the barnacles that attach to them</obo:IAO_0000112>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002574"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002461"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002465"/>
+            <rdf:Description>
+                <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002461"/>
+            </rdf:Description>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002454 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002454">
+        <rdfs:label>has host</rdfs:label>
+        <rdfs:seeAlso>http://eol.org/schema/terms/hasHost</rdfs:seeAlso>
+        <obo:IAO_0000115>X &#39;has host&#39; y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y</obo:IAO_0000115>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002440"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002461 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002461">
+        <rdfs:label>partner in</rdfs:label>
+        <obo:IAO_0000232>Experimental: relation used for defining interaction relations. An interaction relation holds when there is an interaction event with two partners. In a directional interaction, one partner is deemed the subject, the other the target</obo:IAO_0000232>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002464 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002464">
+        <rdfs:label>helper property (not for use in curation)</rdfs:label>
+        <obo:IAO_0000232>This property or its subproperties is not to be used directly. These properties exist as helper properties that are used to support OWL reasoning.</obo:IAO_0000232>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002465 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002465">
+        <rdfs:label>is symbiosis</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002563"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002501 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002501">
@@ -1672,6 +1914,34 @@ Each of these 3 primitives can be composed to yield a cross-product of different
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002502">
         <rdfs:label>depends on</rdfs:label>
         <rdfs:seeAlso rdf:resource="http://purl.obolibrary.org/obo/BFO_0000169"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002563 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002563">
+        <rdfs:label>interaction relation helper property</rdfs:label>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/ro/docs/interaction-relations/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:resource="http://ontologydesignpatterns.org/wiki/Submissions:N-Ary_Relation_Pattern_%28OWL_2%29"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002464"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002574 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002574">
+        <rdfs:label>participates in a biotic-biotic interaction with</rdfs:label>
+        <rdfs:seeAlso rdf:resource="http://dx.doi.org/10.1016/j.ecoinf.2014.08.005"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/ro/subsets#ro-eco"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/COB_0000022"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002437"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
     </owl:ObjectProperty>
@@ -1860,6 +2130,46 @@ Each of these 3 primitives can be composed to yield a cross-product of different
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0016001 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0016001">
+        <rdfs:label>has phenotype or disease</rdfs:label>
+        <terms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-11-05T17:30:14Z</terms:date>
+        <rdfs:seeAlso>https://github.com/oborel/obo-relations/issues/478</rdfs:seeAlso>
+        <obo:IAO_0000232>Do not use this relation directly. It is intended as a grouping for a set of relations regarding presentation of phenotypes and disease.</obo:IAO_0000232>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0002-7463-6306"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0016002 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0016002">
+        <rdfs:label>has disease</rdfs:label>
+        <terms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-11-05T17:30:44Z</terms:date>
+        <rdfs:seeAlso>https://github.com/oborel/obo-relations/issues/478</rdfs:seeAlso>
+        <obo:IAO_0000115>A relationship that holds between an organism and a disease. Here a disease is construed broadly as a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism.</obo:IAO_0000115>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0016001"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0002-7463-6306"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0020105 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0020105">
+        <rdfs:label>is anatomical entity</rdfs:label>
+        <terms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-10-29T09:55:07Z</terms:date>
+        <obo:IAO_0000115>This property only applies to anatomical entities.</obo:IAO_0000115>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0001-6677-8489"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_HOM0000000 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_HOM0000000">
@@ -1900,13 +2210,13 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <rdfs:label xml:lang="en">continuant</rdfs:label>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002214"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_HOM0000000"/>
                 <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_HOM0000000"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002214"/>
                 <owl:allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -2102,6 +2412,19 @@ Each of these 3 primitives can be composed to yield a cross-product of different
     
 
 
+    <!-- http://purl.obolibrary.org/obo/COB_0000022 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/COB_0000022">
+        <rdfs:label xml:lang="en">organism</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <obo:IAO_0000116 xml:lang="en">&#39;Maximal functionally integrated unit&#39; is intended to express unity, which Barry considers synonymous with BFO &#39;object&#39;.</obo:IAO_0000116>
+        <obo:IAO_0000115 xml:lang="en">A material entity that is a maximal functionally integrated unit that develops from a program encoded in a genome</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Includes virus - we will later have a class for cellular organisms.</obo:IAO_0000116>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000078 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000078">
@@ -2128,6 +2451,125 @@ Each of these 3 primitives can be composed to yield a cross-product of different
         <obo:IAO_0000115 xml:lang="en">The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value.</obo:IAO_0000115>
         <obo:IAO_0000111 xml:lang="en">curation status specification</obo:IAO_0000111>
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_33090 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33090">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_4751 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4751">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OGMS_0000031 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000031">
+        <rdfs:label>disease</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
+        <obo:IAO_0000115 xml:lang="en">A disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000001">
+        <rdfs:label>quality</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+        <obo:IAO_0000115>A dependent entity that inheres in a bearer by virtue of how the bearer is related to other entities</obo:IAO_0000115>
+        <oboInOwl:id>PATO:0000001</oboInOwl:id>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465">
+        <rdfs:label>material anatomical entity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <oboInOwl:hasDbXref>VHOG:0001721</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BILA:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:67165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TAO:0001836</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AAO:0010264</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CARO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EHDAA2:0003006</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>Anatomical entity that has mass.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref>HAO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:id>UBERON:0000465</oboInOwl:id>
+        <oboInOwl:hasDbXref>TGMA:0001826</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AEO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#common_anatomy"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#human_subset"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#mouse_subset"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#upper_level"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001062">
+        <rdfs:label>anatomical entity</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0020105"/>
+                <owl:hasSelf rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:hasSelf>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <oboInOwl:hasDbXref>UMLS:C1515976</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>ZFA:0100000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BFO:0000004</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>MA:0000001</oboInOwl:hasDbXref>
+        <obo:IAO_0000115>Biological entity that is either an individual member of a biological species or constitutes the structural organization of an individual member of a biological species.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref>HAO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CARO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>TAO:0100000</oboInOwl:hasDbXref>
+        <oboInOwl:id>UBERON:0001062</oboInOwl:id>
+        <oboInOwl:hasDbXref>TGMA:0001822</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>EHDAA2:0002229</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>NCIT:C12219</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AAO:0010841</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>AEO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>XAO:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>WBbt:0000100</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>FMA:62955</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BILA:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BIRNLEX:6</oboInOwl:hasDbXref>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#common_anatomy"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#human_subset"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#mouse_subset"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.oboInOwllibrary.org/oboInOwl/uberon/core#upper_level"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UPHENO_0001001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UPHENO_0001001">
+        <rdfs:label xml:lang="en">phenotype</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
     </owl:Class>
     
@@ -2277,6 +2719,15 @@ This interpretation is *not* the same as an at-all-times relation</obo:IAO_00001
     
 
 
+    <!-- https://orcid.org/0000-0001-6677-8489 -->
+
+    <owl:NamedIndividual rdf:about="https://orcid.org/0000-0001-6677-8489">
+        <rdfs:label>Aleix Puig-Barbé</rdfs:label>
+        <terms:description>Researcher ORCID=0000-0001-6677-8489</terms:description>
+    </owl:NamedIndividual>
+    
+
+
     <!-- https://orcid.org/0000-0001-7476-6306 -->
 
     <owl:NamedIndividual rdf:about="https://orcid.org/0000-0001-7476-6306">
@@ -2322,12 +2773,33 @@ This interpretation is *not* the same as an at-all-times relation</obo:IAO_00001
     
 
 
+    <!-- https://orcid.org/0000-0002-7463-6306 -->
+
+    <owl:NamedIndividual rdf:about="https://orcid.org/0000-0002-7463-6306">
+        <rdfs:label>Lauren E. Chan</rdfs:label>
+        <terms:description>researcher</terms:description>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://orcid.org/0000-0002-8688-6599 -->
+
+    <owl:NamedIndividual rdf:about="https://orcid.org/0000-0002-8688-6599">
+        <rdfs:label>James P. Balhoff</rdfs:label>
+        <terms:description>researcher</terms:description>
+    </owl:NamedIndividual>
+    
+
+
     <!-- https://orcid.org/0000-0003-1813-6857 -->
 
     <owl:NamedIndividual rdf:about="https://orcid.org/0000-0003-1813-6857">
         <rdfs:label>Pascale Gaudet</rdfs:label>
         <terms:description>Canadian biocurator</terms:description>
     </owl:NamedIndividual>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+    </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
     </rdf:Description>

--- a/src/ontology/ohmi-edit.owl
+++ b/src/ontology/ohmi-edit.owl
@@ -143,8 +143,8 @@
     <!-- http://purl.obolibrary.org/obo/OHMI_0000060 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OHMI_0000060">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000091"/>
-        <rdfs:label xml:lang="en">has disease</rdfs:label>
+        <rdfs:label>obsolete has disease</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -187,8 +187,8 @@
     <!-- http://purl.obolibrary.org/obo/OHMI_0000252 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OHMI_0000252">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000086"/>
-        <rdfs:label xml:lang="en">has phenotype</rdfs:label>
+        <rdfs:label>obsolete has phenotype</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -411,10 +411,10 @@
     <!-- http://purl.obolibrary.org/obo/OHMI_0000481 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OHMI_0000481">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <obo:IAO_0000115>an object subproperty of &apos;has participant&apos; in which the participant is a host organism.</obo:IAO_0000115>
         <obo:IAO_0000117>Oliver He</obo:IAO_0000117>
-        <obo:IAO_0000117>an object subproperty of &apos;has participant&apos; in which the participant is a host organism.</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">has host</rdfs:label>
+        <rdfs:label>obsolete has host</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -466,9 +466,27 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0002200 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002200"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002351 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002351"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002454 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002454"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0016002 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0016002"/>
     
 
 
@@ -1791,12 +1809,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0100026 -->
-
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0100026"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/OHMI_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OHMI_0000001">
@@ -2184,7 +2196,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_219"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -2267,7 +2279,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -2360,7 +2372,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2462,7 +2474,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2526,7 +2538,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2590,7 +2602,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2654,7 +2666,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2718,7 +2730,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2782,7 +2794,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2846,7 +2858,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2910,7 +2922,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -2969,7 +2981,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3071,7 +3083,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3135,7 +3147,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3199,7 +3211,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3268,7 +3280,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3362,7 +3374,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -3404,7 +3416,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3464,7 +3476,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3522,7 +3534,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3587,7 +3599,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3645,7 +3657,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3710,7 +3722,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3777,7 +3789,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3842,7 +3854,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3891,7 +3903,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13250"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -3933,7 +3945,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -3997,7 +4009,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4063,7 +4075,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4128,7 +4140,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4192,7 +4204,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4256,7 +4268,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4320,7 +4332,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4384,7 +4396,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4449,7 +4461,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4583,7 +4595,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4647,7 +4659,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4711,7 +4723,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4829,7 +4841,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4893,7 +4905,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -4957,7 +4969,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5021,7 +5033,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5085,7 +5097,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5149,7 +5161,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5205,7 +5217,7 @@
                                                 <owl:intersectionOf rdf:parseType="Collection">
                                                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                     <owl:Restriction>
-                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13250"/>
                                                     </owl:Restriction>
                                                 </owl:intersectionOf>
@@ -5265,7 +5277,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5329,7 +5341,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5393,7 +5405,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5457,7 +5469,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5548,7 +5560,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5612,7 +5624,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5676,7 +5688,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5725,7 +5737,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -5767,7 +5779,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5832,7 +5844,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5898,7 +5910,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -5962,7 +5974,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6026,7 +6038,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6092,7 +6104,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6183,7 +6195,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6247,7 +6259,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6311,7 +6323,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6403,7 +6415,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6467,7 +6479,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6531,7 +6543,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6580,7 +6592,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -6622,7 +6634,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6686,7 +6698,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6750,7 +6762,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6814,7 +6826,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6878,7 +6890,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -6942,7 +6954,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7060,7 +7072,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7124,7 +7136,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7188,7 +7200,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7252,7 +7264,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7310,7 +7322,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7374,7 +7386,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7438,7 +7450,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7502,7 +7514,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7567,7 +7579,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7632,7 +7644,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7697,7 +7709,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7762,7 +7774,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7827,7 +7839,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7892,7 +7904,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -7957,7 +7969,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8022,7 +8034,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8087,7 +8099,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8152,7 +8164,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8217,7 +8229,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8282,7 +8294,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8347,7 +8359,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8412,7 +8424,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8477,7 +8489,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8542,7 +8554,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8607,7 +8619,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8672,7 +8684,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8737,7 +8749,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8802,7 +8814,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8867,7 +8879,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -8958,7 +8970,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9022,7 +9034,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9086,7 +9098,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9150,7 +9162,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9214,7 +9226,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9278,7 +9290,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9342,7 +9354,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9406,7 +9418,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9471,7 +9483,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9537,7 +9549,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9603,7 +9615,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9669,7 +9681,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9735,7 +9747,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9826,7 +9838,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9890,7 +9902,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -9954,7 +9966,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10018,7 +10030,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10082,7 +10094,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10234,7 +10246,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10298,7 +10310,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10538,7 +10550,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10602,7 +10614,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10666,7 +10678,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -10730,7 +10742,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -12716,7 +12728,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -12868,7 +12880,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -12932,7 +12944,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -12996,7 +13008,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13060,7 +13072,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13124,7 +13136,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13202,7 +13214,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13266,7 +13278,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13330,7 +13342,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13394,7 +13406,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13458,7 +13470,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13514,7 +13526,7 @@
                                                 <owl:intersectionOf rdf:parseType="Collection">
                                                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                     <owl:Restriction>
-                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13250"/>
                                                     </owl:Restriction>
                                                 </owl:intersectionOf>
@@ -13574,7 +13586,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13638,7 +13650,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13702,7 +13714,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13763,7 +13775,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13897,7 +13909,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7147"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -13961,7 +13973,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14025,7 +14037,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14089,7 +14101,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14153,7 +14165,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14217,7 +14229,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14281,7 +14293,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14345,7 +14357,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14409,7 +14421,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14473,7 +14485,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14537,7 +14549,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14601,7 +14613,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14665,7 +14677,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14729,7 +14741,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14793,7 +14805,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14857,7 +14869,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14921,7 +14933,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9074"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -14985,7 +14997,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15049,7 +15061,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15113,7 +15125,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15177,7 +15189,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15241,7 +15253,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15305,7 +15317,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15369,7 +15381,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15433,7 +15445,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13189"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15612,7 +15624,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15676,7 +15688,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15740,7 +15752,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15804,7 +15816,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15869,7 +15881,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15933,7 +15945,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -15997,7 +16009,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16061,7 +16073,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16125,7 +16137,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16189,7 +16201,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16253,7 +16265,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16317,7 +16329,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16381,7 +16393,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16445,7 +16457,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16509,7 +16521,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16573,7 +16585,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16637,7 +16649,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16701,7 +16713,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16765,7 +16777,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16829,7 +16841,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16888,7 +16900,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -16952,7 +16964,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9008"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17016,7 +17028,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/MONDO_0019437"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17283,7 +17295,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17341,7 +17353,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17402,7 +17414,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17460,7 +17472,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17519,7 +17531,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17577,7 +17589,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17641,7 +17653,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17699,7 +17711,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17757,7 +17769,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17815,7 +17827,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17873,7 +17885,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17931,7 +17943,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -17989,7 +18001,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18047,7 +18059,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18105,7 +18117,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18163,7 +18175,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18221,7 +18233,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18279,7 +18291,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18337,7 +18349,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18395,7 +18407,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18453,7 +18465,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18511,7 +18523,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18569,7 +18581,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18627,7 +18639,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18685,7 +18697,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18743,7 +18755,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18802,7 +18814,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18860,7 +18872,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18918,7 +18930,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -18976,7 +18988,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19034,7 +19046,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19092,7 +19104,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19150,7 +19162,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19208,7 +19220,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19266,7 +19278,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19324,7 +19336,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19382,7 +19394,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19440,7 +19452,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19498,7 +19510,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19556,7 +19568,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19614,7 +19626,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19672,7 +19684,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19736,7 +19748,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19796,7 +19808,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19854,7 +19866,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19915,7 +19927,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -19973,7 +19985,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20033,7 +20045,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20091,7 +20103,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20149,7 +20161,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20207,7 +20219,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20266,7 +20278,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20324,7 +20336,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20382,7 +20394,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20484,7 +20496,7 @@
                         <owl:intersectionOf rdf:parseType="Collection">
                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
@@ -20526,7 +20538,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20589,7 +20601,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20647,7 +20659,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20705,7 +20717,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20763,7 +20775,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20814,7 +20826,7 @@
                                                 <owl:intersectionOf rdf:parseType="Collection">
                                                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                     <owl:Restriction>
-                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_13250"/>
                                                     </owl:Restriction>
                                                 </owl:intersectionOf>
@@ -20874,7 +20886,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20933,7 +20945,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -20991,7 +21003,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21049,7 +21061,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21107,7 +21119,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21165,7 +21177,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21223,7 +21235,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21283,7 +21295,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21343,7 +21355,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21403,7 +21415,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21464,7 +21476,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21524,7 +21536,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21584,7 +21596,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21646,7 +21658,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21706,7 +21718,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21767,7 +21779,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21827,7 +21839,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21887,7 +21899,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -21948,7 +21960,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22008,7 +22020,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22068,7 +22080,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22131,7 +22143,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22191,7 +22203,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22249,7 +22261,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22307,7 +22319,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22371,7 +22383,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22429,7 +22441,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22487,7 +22499,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22546,7 +22558,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22606,7 +22618,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22664,7 +22676,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22722,7 +22734,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22780,7 +22792,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22838,7 +22850,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22896,7 +22908,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -22954,7 +22966,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23012,7 +23024,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23071,7 +23083,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23133,7 +23145,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23194,7 +23206,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23255,7 +23267,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23313,7 +23325,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23371,7 +23383,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23430,7 +23442,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23490,7 +23502,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23550,7 +23562,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23611,7 +23623,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23672,7 +23684,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23732,7 +23744,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23792,7 +23804,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23856,7 +23868,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23917,7 +23929,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -23976,7 +23988,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24040,7 +24052,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24100,7 +24112,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24159,7 +24171,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24226,7 +24238,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24284,7 +24296,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24348,7 +24360,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24406,7 +24418,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24464,7 +24476,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24522,7 +24534,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24580,7 +24592,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24638,7 +24650,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24702,7 +24714,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24760,7 +24772,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24818,7 +24830,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24876,7 +24888,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24934,7 +24946,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -24992,7 +25004,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25052,7 +25064,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25112,7 +25124,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25171,7 +25183,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25230,7 +25242,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25289,7 +25301,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25348,7 +25360,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25407,7 +25419,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25471,7 +25483,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25529,7 +25541,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25587,7 +25599,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25645,7 +25657,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25703,7 +25715,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25761,7 +25773,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25819,7 +25831,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25878,7 +25890,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -25941,7 +25953,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26000,7 +26012,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26059,7 +26071,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26118,7 +26130,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26177,7 +26189,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26236,7 +26248,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26300,7 +26312,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26359,7 +26371,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26418,7 +26430,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26477,7 +26489,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_9256"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26536,7 +26548,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -26600,7 +26612,7 @@
                                                         <owl:intersectionOf rdf:parseType="Collection">
                                                             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
                                                             <owl:Restriction>
-                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OHMI_0000060"/>
+                                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0016002"/>
                                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/DOID_7148"/>
                                                             </owl:Restriction>
                                                         </owl:intersectionOf>
@@ -27253,5 +27265,5 @@
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
OHMI IRI |	Label|	replace with RO IRI
--|--|--
http://purl.obolibrary.org/obo/OHMI_0000060	|has disease	|[http://purl.obolibrary.org/obo/RO_0016002](http://purl.obolibrary.org/obo/RO_0016002)
http://purl.obolibrary.org/obo/OHMI_0000252	|has phenotype	|[http://purl.obolibrary.org/obo/RO_0002200](http://purl.obolibrary.org/obo/RO_0002200)
http://purl.obolibrary.org/obo/OHMI_0000481	|has host	|[http://purl.obolibrary.org/obo/RO_0002454](http://purl.obolibrary.org/obo/RO_0002454)

Three OHMI relations are deprecated.